### PR TITLE
Add ability to exclude jobs

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -5,6 +5,8 @@ jenkins:
   user: ""
   jobs:
     - proj
+  excluded_jobs:
+    - exact_job_name
 
 coffee:
   endpoint: 'https://api.thingspeak.com/channels/125608/fields/1.json?sum=daily&timezone=Europe/Warsaw&days=1'

--- a/src/jenkins_client.py
+++ b/src/jenkins_client.py
@@ -3,6 +3,7 @@ import jenkins
 class JenkinsClient():
   def __init__(self, config):
     self.jobs = config['jobs']
+    self.excluded_jobs = config['excluded_jobs']
     self.client = jenkins.Jenkins(
       url=config['url'],
       username=config['user'],
@@ -10,6 +11,9 @@ class JenkinsClient():
     )
 
   def is_observed(self, other_job_name):
+    for job_name in self.excluded_jobs:
+      if other_job_name == job_name:
+        return False
     for job_name in self.jobs:
       if other_job_name.startswith(job_name):
         return True


### PR DESCRIPTION
Hi @macbury ,

This adds the ability to exclude some jobs from affecting the output, e.g. when you want to include all results for `group_*`, but exclude `group_specific_member`.